### PR TITLE
Bitbucket support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - CircleCI support
 - Enforce updates to `CHANGELOG.md` for PRs
+- Support bitbucket repos
 
 ## [2.1.0][] - 2017-05-25
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ Where `<version number>` is the more recently previous release of this module.
 
 ## Options
 
-The cli takes a single optional parameter:
-the changelog filename:
+The cli takes two optional parameters:
+- the changelog filename
+- the remote code repository (github, or bitbucket - used to generate URL's for versions).
+  Default is github
 
 ```
-changelog-verify [filename]
+changelog-verify [filename] [--remote=bitbucket|github]
 ```
 
 `filename` can be a path relative to the current working directory,

--- a/cli.js
+++ b/cli.js
@@ -4,8 +4,12 @@ var fs = require('fs');
 var upath = require('upath');
 var versionChangelog = require('./index');
 var packageJson = require(upath.join(process.cwd(), 'package.json'));
+var minimist = require('minimist');
 
-var fileName = process.argv[2] || 'CHANGELOG.md';
+var argv = minimist(process.argv.slice(2));
+
+var fileName = argv._[0] || 'CHANGELOG.md';
+var remote = argv.remote === 'bitbucket' ? 'bitbucket' : 'github';
 
 if (!upath.isAbsolute(fileName)) {
   fileName = upath.normalize(upath.join(process.cwd(), fileName));
@@ -19,7 +23,7 @@ var version = packageJson.version;
 
 var data = fs.readFileSync(fileName, 'utf8');
 
-versionChangelog(data, version, function(error, data) {
+versionChangelog(data, { version: version, remote: remote }, function(error, data) {
 
   if (error) {
     console.error(error.message || error.toString());

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
 var fs = require('fs');
 var spawn = require('cross-spawn');
 var githubUrlFromGit = require('github-url-from-git');
+var bitbucketUrlFromGit = require('bitbucket-url-from-git');
 var hasYarn = require('has-yarn');
+var gitRemote = require('./util/git-remote');
 
 function dateWithLeadingZero(date) {
   return ('0' + date).slice(-2);
@@ -33,37 +35,87 @@ function getVersionPrefix() {
   return versionPrefix;
 }
 
-function updateCompareUri(data, versionString) {
-  
-  var versionWithPrefix = getVersionPrefix() + versionString;
+function githubUris(data, newVersion) {
+  var remoteUrl;
+  var previousVersion;
+  var previousLink;
+  var prefix = getVersionPrefix();
 
-  var unreleasedLinkPattern = /\[Unreleased\]: (.*compare\/)(.*)\.\.\.HEAD/g;
+  // Try get previous version and remote from unreleased tag if it exists
+  var match = /\[Unreleased\]: (.*)\/compare\/(.*)\.\.\.HEAD/g.exec(data);
 
-  if (unreleasedLinkPattern.test(data)) {
-
-    return data.replace(
-      unreleasedLinkPattern,
-      '[Unreleased]: $1' + versionWithPrefix + '...HEAD\n[' + versionString + ']: $1$2...' + versionWithPrefix
-    );
-
+  if (match) {
+    remoteUrl = match[1];
+    previousVersion = match[2];
   }
 
-  var originUrl = spawn.sync('git', ['config', '--get', 'remote.origin.url']).stdout.toString().trim();
-
-  if (!originUrl) {
-    throw new Error('Unable to determine origin URL for adding to changelog - ensure you have initialized a git repository');
+  if (!remoteUrl) {
+    remoteUrl = githubUrlFromGit(gitRemote());
   }
 
-  var compareUrl = githubUrlFromGit(originUrl) + '/compare';
-  var treeUrl = githubUrlFromGit(originUrl) + '/tree/' + versionWithPrefix;
+  if (previousVersion) {
+    previousLink = '[' + newVersion + ']: ' + remoteUrl + '/compare/' + previousVersion + '...' + prefix + newVersion;
+  } else {
+    previousLink = '[' + newVersion + ']: ' + remoteUrl + '/tree/' + prefix + newVersion;
+  }
 
-  return data
-    + '\n\n[Unreleased]: ' + compareUrl + '/' + versionWithPrefix + '...HEAD'
-    + '\n[' + versionString + ']: ' + treeUrl;
-
+  return {
+    unreleased: '[Unreleased]: ' + remoteUrl + '/compare/' + prefix + newVersion + '...HEAD',
+    previous: previousLink
+  };
 }
 
-module.exports = function versionChangelog(data, version, done) {
+function bitbucketUris(data, newVersion) {
+  var remoteUrl;
+  var previousVersion;
+  var previousLink;
+  var prefix = getVersionPrefix();
+
+  // Try get previous version and remote from unreleased tag if it exists
+  var match = /\[Unreleased\]: (.*)\/branches\/compare\/master%0D(.*)/g.exec(data);
+
+  if (match) {
+    remoteUrl = match[1];
+    previousVersion = match[2];
+  }
+
+  if (!remoteUrl) {
+    remoteUrl = bitbucketUrlFromGit(gitRemote());
+  }
+
+  if (previousVersion) {
+    previousLink = '[' + newVersion + ']: ' + remoteUrl + '/branches/compare/' + prefix + newVersion + '%0D' + previousVersion;
+  } else {
+    previousLink = '[' + newVersion + ']: ' + remoteUrl + '/commits/tag/' + prefix + newVersion;
+  }
+
+  return {
+    unreleased: '[Unreleased]: ' + remoteUrl + '/branches/compare/master%0D' + prefix + newVersion,
+    previous: previousLink
+  };
+}
+
+const UriFunctions = {
+  'github': githubUris,
+  'bitbucket': bitbucketUris,
+}
+
+
+function updateCompareUri(data, versionString, repository) {
+
+  var remoteUrl;
+  var uris = UriFunctions[repository](data, versionString);
+
+  if (data.match(/\[Unreleased\]:/)) {
+    return data.replace(/\[Unreleased\]:.*/, uris.unreleased + '\n' + uris.previous);
+  }
+
+  return data
+    + '\n\n' + uris.unreleased 
+    + '\n' + uris.previous;
+}
+
+module.exports = function versionChangelog(data, { version, repository }, done) {
 
   try {
 
@@ -72,7 +124,7 @@ module.exports = function versionChangelog(data, version, done) {
 
     // Update the [Unreleased] URI
     // and add the new version URI
-    data = updateCompareUri(data, version);
+    data = updateCompareUri(data, version, repository ? repository : 'github');
 
     done(null, data);
 

--- a/index.js
+++ b/index.js
@@ -101,10 +101,10 @@ const UriFunctions = {
 }
 
 
-function updateCompareUri(data, versionString, repository) {
+function updateCompareUri(data, versionString, remote) {
 
   var remoteUrl;
-  var uris = UriFunctions[repository](data, versionString);
+  var uris = UriFunctions[remote](data, versionString);
 
   if (data.match(/\[Unreleased\]:/)) {
     return data.replace(/\[Unreleased\]:.*/, uris.unreleased + '\n' + uris.previous);
@@ -115,7 +115,7 @@ function updateCompareUri(data, versionString, repository) {
     + '\n' + uris.previous;
 }
 
-module.exports = function versionChangelog(data, { version, repository }, done) {
+module.exports = function versionChangelog(data, { version, remote}, done) {
 
   try {
 
@@ -124,7 +124,7 @@ module.exports = function versionChangelog(data, { version, repository }, done) 
 
     // Update the [Unreleased] URI
     // and add the new version URI
-    data = updateCompareUri(data, version, repository ? repository : 'github');
+    data = updateCompareUri(data, version, remote ? remote : 'github');
 
     done(null, data);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -488,8 +488,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
+    "@std/esm": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@std/esm/-/esm-0.23.4.tgz",
+      "integrity": "sha512-S+gN8dIuCmNn84Maa2DNBhJK38hQh/0Fm1c6Njc2YBjE+xpnj039T8jSZpyv74pvbjoZdaGAJNP/uhVqaf+uTw==",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -15,6 +30,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bitbucket-url-from-git": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bitbucket-url-from-git/-/bitbucket-url-from-git-1.0.0.tgz",
+      "integrity": "sha512-YbhXoQoJs97aA7mk90Ch/2xTQuXtgI8nfsxBoauqgaEVB3pZ1Pl4Nz0KOyzEEONZIDtMBukBL7m7wj94VWON6Q=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -132,6 +152,16 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
     },
     "find-up": {
       "version": "1.1.2",
@@ -264,10 +294,22 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -279,6 +321,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
     "load-json-file": {
@@ -344,6 +392,12 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -366,6 +420,12 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -409,6 +469,12 @@
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -462,11 +528,30 @@
         "supports-color": "3.1.2"
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
+      "integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -525,6 +610,15 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -555,6 +649,17 @@
       "dev": true,
       "requires": {
         "pinkie": "2.0.4"
+      }
+    },
+    "proxyquire": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.0.tgz",
+      "integrity": "sha512-TO9TAIz0mpa+SKddXsgCFatoe/KmHvoNVj2jDMC1kXE6kKn7/4CRpxvQ+0wAK9sbMT2FVO89qItlvnZMcFbJ2Q==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
       }
     },
     "pseudomap": {
@@ -602,6 +707,18 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -613,6 +730,39 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.3.tgz",
+      "integrity": "sha512-pwvXHQbLuZR2GPylhm7JII9lCYqLxwpixCqKDELWyrmqRKlNgAxslWTVVbm2EOu4vSQ3cY/Lc0IF0d36OJTLcg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "@std/esm": "0.23.4",
+        "diff": "3.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.0",
+        "supports-color": "5.3.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -662,10 +812,22 @@
         "has-flag": "1.0.0"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cross-spawn": "^4.0.2",
     "github-url-from-git": "^1.4.0",
     "has-yarn": "^1.0.0",
+    "minimist": "^1.2.0",
     "upath": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Jess Telford <hi+npm@jes.st> (http://jes.st)",
   "license": "ISC",
   "dependencies": {
+    "bitbucket-url-from-git": "^1.0.0",
     "cross-spawn": "^4.0.2",
     "github-url-from-git": "^1.4.0",
     "has-yarn": "^1.0.0",
@@ -22,6 +23,8 @@
   },
   "devDependencies": {
     "changelog-verify": "^1.1.0",
-    "mocha": "^3.1.2"
+    "mocha": "^3.1.2",
+    "proxyquire": "^2.0.0",
+    "sinon": "^4.4.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -131,7 +131,7 @@ describe(`Versioning Changelog (prefix source: "${prefixSource}")`, function() {
       `.trim(),
       {
         version: '1.0.0',
-        repository: 'bitbucket',
+        remote: 'bitbucket',
       },
       function(error, data) {
 
@@ -172,7 +172,7 @@ describe(`Versioning Changelog (prefix source: "${prefixSource}")`, function() {
       `.trim(),
       {
         version: '2.0.0',
-        repository: 'bitbucket',
+        remote: 'bitbucket',
       },
       function(error, data) {
 

--- a/util/git-remote.js
+++ b/util/git-remote.js
@@ -1,0 +1,13 @@
+var spawn = require('cross-spawn');
+
+function gitRemote() {
+  var remoteUrl = spawn.sync('git', ['config', '--get', 'remote.origin.url']).stdout.toString().trim();
+
+  if (!remoteUrl) {
+    throw new Error('Unable to determine origin URL for adding to changelog - ensure you have initialized a git repository');
+  }
+
+  return remoteUrl;
+}
+
+module.exports = gitRemote;


### PR DESCRIPTION
Adds support for bitbucket repos - if you pass in the new flag `--remote=bitbucket` it generates the correct urls for bitbucket style repos.

Can also be extended to support other kinds of repos down the line.