### PR TITLE
Bump long out of date upath

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "giturl": "^1.0.0",
     "has-yarn": "^1.0.0",
     "minimist": "^1.2.0",
-    "upath": "^0.2.0"
+    "upath": "^1.1.0"
   },
   "devDependencies": {
     "changelog-verify": "^1.1.0",


### PR DESCRIPTION
`upath@0.2.0` specifies `engines: { node: ">=0.10 <=5" }` in `package.json` that causes installation to fail using modern node engines. The latest `upath` doesn't break compatibility with the [existing references](https://github.com/jesstelford/version-changelog/blob/4621d0a66b79558ffd3c258a0896e44c2f1e3f19/cli.js#L16) in the codebase.