### PR TITLE
Fix GitLab compare URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Corrected documentation on usage
+- Fixed GitLab compare URLs
 
 ## [3.1.1][] - 2018-12-22
 

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function gitlabUris(data, newVersion) {
   var prefix = getVersionPrefix();
 
   // Try get previous version and remote from unreleased tag if it exists
-  var match = /\[Unreleased\]: (.*)\/compare\/master...(.*)/g.exec(data);
+  var match = /\[Unreleased\]: (.*)\/compare\/(.*)...master/g.exec(data);
 
   if (match) {
     remoteUrl = match[1];
@@ -117,13 +117,13 @@ function gitlabUris(data, newVersion) {
   }
 
   if (previousVersion) {
-    previousLink = '[' + newVersion + ']: ' + remoteUrl + '/compare/' + prefix + newVersion + '...' + previousVersion;
+    previousLink = '[' + newVersion + ']: ' + remoteUrl + '/compare/' + previousVersion + '...' + prefix + newVersion;
   } else {
     previousLink = '[' + newVersion + ']: ' + remoteUrl + '/tags/' + prefix + newVersion;
   }
 
   return {
-    unreleased: '[Unreleased]: ' + remoteUrl + '/compare/master...' + prefix + newVersion,
+    unreleased: '[Unreleased]: ' + remoteUrl + '/compare/' + prefix + newVersion + '...master',
     previous: previousLink
   };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -146,7 +146,7 @@ describe(`Versioning Changelog (prefix source: "${prefixSource}")`, function() {
 ## [1.0.0][] - ${todayDate}
 - Foo
 
-[Unreleased]: http://gitlab.com/jesstelford/version-changelog/compare/master...${versionPrefix}1.0.0
+[Unreleased]: http://gitlab.com/jesstelford/version-changelog/compare/${versionPrefix}1.0.0...master
 [1.0.0]: http://gitlab.com/jesstelford/version-changelog/tags/${versionPrefix}1.0.0
           `.trim());
 
@@ -168,7 +168,7 @@ describe(`Versioning Changelog (prefix source: "${prefixSource}")`, function() {
 ## [1.0.0][] - 2016-10-10
 - Bar
 
-[Unreleased]: http://gitlab.com/jesstelford/version-changelog/compare/master...${versionPrefix}1.0.0
+[Unreleased]: http://gitlab.com/jesstelford/version-changelog/compare/${versionPrefix}1.0.0...master
 [1.0.0]: http://gitlab.com/jesstelford/version-changelog/tags/${versionPrefix}1.0.0
 
         `.trim(),
@@ -190,8 +190,8 @@ describe(`Versioning Changelog (prefix source: "${prefixSource}")`, function() {
 ## [1.0.0][] - 2016-10-10
 - Bar
 
-[Unreleased]: http://gitlab.com/jesstelford/version-changelog/compare/master...${versionPrefix}2.0.0
-[2.0.0]: http://gitlab.com/jesstelford/version-changelog/compare/${versionPrefix}2.0.0...${versionPrefix}1.0.0
+[Unreleased]: http://gitlab.com/jesstelford/version-changelog/compare/${versionPrefix}2.0.0...master
+[2.0.0]: http://gitlab.com/jesstelford/version-changelog/compare/${versionPrefix}1.0.0...${versionPrefix}2.0.0
 [1.0.0]: http://gitlab.com/jesstelford/version-changelog/tags/${versionPrefix}1.0.0
           `.trim());
 


### PR DESCRIPTION
GitLab compare URLs have this format: `<compareURL>/<old>...<new>`. This package puts it the other way around (maybe GitLab changed the format at some point?). This pull request corrects the format of the URLs.

Once again (I have choosen a random project that does not even use this package):
Wrong: https://gitlab.com/antora/antora/compare/master...v2.0.0
Correct: https://gitlab.com/antora/antora/compare/v2.0.0...master

### Discussion needed

This is a breaking change for everybody using this package with their GitLab Repo. Present links will not be corrected. So this fix will work best for new project or after manually fixing the present links first. I am not sure if there should be code added to do a correction of present links. What do you think about that?

Before:
```markdown
[Unreleased]: http://gitlab-project/compare/master...v0.10.1
[0.10.1]: http://gitlab-project/compare/v0.10.1...v0.10.0
[0.10.0]: http://gitlab-project/compare/v0.10.0...v0.9.5
...
[0.1.1]: http://gitlab-project/compare/v0.1.1...v0.1.0
[0.1.0]: http://gitlab-project/tags/v0.1.0
```

After:
```markdown
[Unreleased]: http://gitlab-project/compare/v0.10.1...master
[0.10.1]: http://gitlab-project/tags/v0.10.1
[0.10.1]: http://gitlab-project/compare/v0.10.1...v0.10.0
[0.10.0]: http://gitlab-project/compare/v0.10.0...v0.9.5
...
[0.1.1]: http://gitlab-project/compare/v0.1.1...v0.1.0
[0.1.0]: http://gitlab-project/tags/v0.1.0
```